### PR TITLE
Issue 6: Parse `oeid` from incoming link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It's possible to use the SDK functionality from either a Swift or Objective-C iO
   - [Targeting API](#targeting-api-1)
   - [Witness API](#witness-api-1)
   - [Integrating GAM360](#integrating-gam360-1)
+- [Identifying visitors arriving from Email newsletters](#identifying-visitors-arriving-from-email-newsletters)
+  - [Insert oeid into your Email newsletter template](#insert-oeid-into-your-email-newsletter-template)
+  - [Capture clicks on universal links in your application](#capture-clicks-on-universal-links-in-your-application)
+  - [Call tryIdentifyFromURL SDK API](#call-tryidentifyfromurl-sdk-api)
 - [Demo Applications](#demo-applications)
   - [Building](#building)
 
@@ -328,6 +332,56 @@ We can further extend the above `targetingOk` example delegate implementation to
 ```
 
 It's assumed in the above code snippet that `self.bannerView` is a pointer to a `DFPBannerView` instance which resides in your delegate and which has already been initialized and configured by a view controller.
+
+## Identifying visitors arriving from Email newsletters
+
+If you send Email newsletters that contain links to your application (e.g., universal links), then you may want to automatically _identify_ visitors that have clicked on any such links via their Email address. Incoming application traffic which is originating from a subscriber click on a link in a newsletter is considered to be implicitly authenticated by the recipient of the Email, therefore serving as an excellent source of linking of online user identifies.
+
+### Insert oeid into your Email newsletter template
+
+To enable automatic identification of visitors originating from your Email newsletter, you first need to include an **oeid** parameter in the query string of all links to your website in your Email newsletter template. The value of the **oeid** parameter should be set to the SHA256 hash of the lowercased Email address of the recipient. For example, if you are using [Braze](https://www.braze.com/) to send your newsletters, you can easily encode the SHA256 hash value of the recipient's Email address by setting the **oeid** parameter in the query string of any links to your application as follows:
+
+```
+oeid={{${email_address} | downcase | sha2}}
+```
+
+The above example uses various personalization tags as documented in [Braze's user guide](https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/) to dynamically insert the required data into an **oeid** parameter, all of which should make up a _part_ of the destination URL in your template.
+
+### Capture clicks on universal links in your application
+
+In order for your application to open on devices where it is installed when a link to your domain is clicked, you need to [configure and prepare your application to handle universal links](https://developer.apple.com/ios/universal-links/) first.
+
+### Call tryIdentifyFromURL SDK API
+
+When iOS launches your app after a user taps a universal link, you receive an `NSUserActivity` object with an `activityType` value of `NSUserActivityTypeBrowsingWeb`. The activity object's `webpageURL` property contains the URL that the user is accessing. You can then pass it to the SDK's `tryIdentifyFromURL()` API which will automatically look for `oeid` in the query string of the URL and call `identify` with its value if found.
+
+#### Swift
+
+```swift
+func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+	if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+    let url = userActivity.webpageURL!
+    try OPTABLE!.tryIdentifyFromURL(url)
+  }
+  ...
+}
+```
+
+#### Objective-C
+
+```objective-c
+-(BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
+
+	if ([userActivity.activityType isEqualToString: NSUserActivityTypeBrowsingWeb]) {
+    NSURL *url = userActivity.webpageURL;
+    NSError *error = nil;
+		[OPTABLE tryIdentifyFromURL :url.absoluteString error:&error];
+    ...
+  }
+	...
+
+}
+```
 
 ## Demo Applications
 

--- a/Tests/OptableSDKTests.swift
+++ b/Tests/OptableSDKTests.swift
@@ -64,6 +64,34 @@ class OptableSDKTests: XCTestCase {
         XCTAssertNotEqual(unexpected, sdk.cid("foobarBAZ-01234#98765.!!!"))
     }
 
+    func test_eidFromURL_isCorrect() throws {
+        let url = "http://some.domain.com/some/path?some=query&something=else&oeid=a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3&foo=bar&baz"
+        let expected = "e:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+
+        XCTAssertEqual(expected, sdk.eidFromURL(url))
+    }
+
+    func test_eidFromURL_returnsEmptyWhenOeidAbsent() throws {
+        let url = "http://some.domain.com/some/path?some=query&something=else"
+        let expected = ""
+
+        XCTAssertEqual(expected, sdk.eidFromURL(url))
+    }
+
+    func test_eidFromURL_expectsSHA256() throws {
+        let url = "http://some.domain.com/some/path?some=query&something=else&oeid=AAAAAAAa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3&foo=bar&baz"
+        let expected = ""
+
+        XCTAssertEqual(expected, sdk.eidFromURL(url))
+    }
+
+    func test_eidFromURL_ignoresCase() throws {
+        let url = "http://some.domain.com/some/path?some=query&something=else&oEId=A665A45920422F9D417E4867EFDC4FB8A04A1F3FFF1FA07E998E86f7f7A27AE3&foo=bar&baz"
+        let expected = "e:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+
+        XCTAssertEqual(expected, sdk.eidFromURL(url))
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
Issue 6: Parse `oeid` from incoming link querystring and auto-identify with eid when present

- Implement OptableSDK.eidFromURL(urlString) and tests
- tryIdentifyFromURL(urlString) auto-calls identify when oeid found in urlString params
- README docs for tryIdentifyFromURL