### PR TITLE
targetingFromCache and targetingClearCache APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ do {
 
 On success, the resulting key values are typically sent as part of a subsequent ad call. Therefore we recommend that you either call `targeting()` before each ad call, or in parallel periodically, caching the resulting key values which you then provide in ad calls.
 
+#### Caching Targeting Data
+
+The `targeting` API will automatically cache resulting key value data in client storage on success. You can subsequently retrieve the cached key value data as follows:
+
+```swift
+let cachedTargetingData = OPTABLE!.targetingFromCache()
+if (cachedTargetingData != nil) {
+  // cachedTargetingData! is an NSDictionary which you can cast as! [String: Any]
+}
+```
+
+You can also clear the locally cached targeting data:
+
+```swift
+OPTABLE!.targetingClearCache()
+```
+
+Note that both `targetingFromCache()` and `targetingClearCache()` are synchronous.
+
 ### Witness API
 
 To send real-time event data from the user's device to the sandbox for eventual audience assembly, you can call the witness API as follows:
@@ -309,6 +328,30 @@ To get the targeting key values associated by the configured sandbox with the de
 NSError *error = nil;
 [OPTABLE targetingAndReturnError:&error];
 ```
+
+#### Caching Targeting Data
+
+The `targetingAndReturnError` method will automatically cache resulting key value data in client storage on success. You can subsequently retrieve the cached key value data as follows:
+
+```objective-c
+@import OptableSDK;
+...
+NSDictionary *cachedTargetingData = nil;
+cachedTargetingData = [OPTABLE targetingFromCache];
+if (cachedTargetingData != nil) {
+  // cachedTargetingData! is an NSDictionary
+}
+```
+
+You can also clear the locally cached targeting data:
+
+```objective-c
+@import OptableSDK;
+...
+[OPTABLE targetingClearCache];
+```
+
+Note that both `targetingFromCache` and `targetingClearCache` are synchronous.
 
 ### Witness API
 

--- a/Source/Core/LocalStorage.swift
+++ b/Source/Core/LocalStorage.swift
@@ -12,13 +12,16 @@
 import Foundation
 
 class LocalStorage: NSObject {
-    let keyPfx: String = "OPTABLE_"
+    let keyPfx: String = "OPTABLE"
     var passportKey: String
+    var targetingKey: String
 
     init(_ config: Config) {
-        // The key used for storing the passport should be unique to the host+app that this instance was initialized with:
-        let utf8str = (config.host + "/" + config.app).data(using: .utf8)
-        self.passportKey = self.keyPfx + utf8str!.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
+        // The key used for storage should be unique to the host+app that this instance was initialized with:
+        let utf8str = (config.host + "/" + config.app).data(using: .utf8)!.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
+
+        self.passportKey = self.keyPfx + "_PASS_" + utf8str
+        self.targetingKey = self.keyPfx + "_TGT_" + utf8str
     }
 
     func getPassport() -> String? {
@@ -27,5 +30,17 @@ class LocalStorage: NSObject {
 
     func setPassport(_ passport: String) -> Void {
         UserDefaults.standard.set(passport, forKey: passportKey)
-    }    
+    }
+
+    func getTargeting() -> [String: Any]? {
+        return UserDefaults.standard.dictionary(forKey: targetingKey)
+    }
+
+    func setTargeting(_ keyvalues: [String: Any]) -> Void {
+        UserDefaults.standard.setValue(keyvalues, forKey: targetingKey)
+    }
+
+    func clearTargeting() -> Void {
+        UserDefaults.standard.removeObject(forKey: targetingKey)
+    }
 }

--- a/Source/Edge/Targeting.swift
+++ b/Source/Edge/Targeting.swift
@@ -2,7 +2,8 @@
 //  Targeting.swift
 //  OptableSDK
 //
-//  Created by Bosko Milekic on 2020-08-26.
+//  Copyright © 2020 Optable Technologies, Inc. All rights reserved.
+//  See LICENSE for details.
 //
 
 import Foundation

--- a/demo-ios-objc/Podfile.lock
+++ b/demo-ios-objc/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.67.1):
+  - Google-Mobile-Ads-SDK (7.68.0):
     - GoogleAppMeasurement (~> 7.0)
     - GoogleUserMessagingPlatform (~> 1.1)
   - GoogleAppMeasurement (7.0.0):
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: 4c11bba9a823ed16c42f14d42feebc7678fbfd6a
+  Google-Mobile-Ads-SDK: 29bbdb182d69ff606cc0301da1590b40be8d2205
   GoogleAppMeasurement: 7790ef975d1d463c8614cd949a847e612edf087a
   GoogleUserMessagingPlatform: 1d4b6946710d18cec34742054092e2c2bddae61f
   GoogleUtilities: ffb2f4159f2c897c6e8992bd7fbcdef8a300589c

--- a/demo-ios-objc/demo-ios-objc/Base.lproj/Main.storyboard
+++ b/demo-ios-objc/demo-ios-objc/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9KB-Po-ioE">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -43,7 +43,7 @@
                                         <rect key="frame" x="0.0" y="138" width="374" height="30"/>
                                         <state key="normal" title="Identify"/>
                                         <connections>
-                                            <action selector="dispatchIdentify:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Sae-rS-iHh"/>
+                                            <action selector="dispatchIdentify:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CNy-Db-Mwd"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -92,30 +92,52 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4k-D7-Mvh">
                                 <rect key="frame" x="50" y="94" width="314" height="30"/>
-                                <state key="normal" title="Load Banner"/>
+                                <state key="normal" title="Load Targeting and Banner"/>
                                 <connections>
-                                    <action selector="loadBannerWithTargeting:" destination="qnL-ha-uwz" eventType="touchUpInside" id="hBs-SW-Fgz"/>
+                                    <action selector="loadBannerWithTargeting:" destination="qnL-ha-uwz" eventType="touchUpInside" id="2sa-1R-eGT"/>
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="c00-PY-Cdm">
-                                <rect key="frame" x="50" y="157" width="314" height="370"/>
+                                <rect key="frame" x="50" y="210" width="314" height="401"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hXv-1T-mbc">
+                                <rect key="frame" x="50" y="126" width="314" height="30"/>
+                                <state key="normal" title="Cached Targeting and Banner"/>
+                                <connections>
+                                    <action selector="loadBannerWithTargetingFromCache:" destination="qnL-ha-uwz" eventType="touchUpInside" id="dWK-eA-gis"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Jw-Ws-T0T">
+                                <rect key="frame" x="50" y="158" width="314" height="30"/>
+                                <state key="normal" title="Clear Targeting Cache"/>
+                                <connections>
+                                    <action selector="clearTargetingCache:" destination="qnL-ha-uwz" eventType="touchUpInside" id="Ll8-bx-lvM"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Cyy-8b-GCg"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="1Jw-Ws-T0T" firstAttribute="top" secondItem="hXv-1T-mbc" secondAttribute="bottom" constant="2" id="C0X-HG-eYe"/>
+                            <constraint firstItem="hXv-1T-mbc" firstAttribute="top" secondItem="x4k-D7-Mvh" secondAttribute="bottom" constant="2" id="D1p-oM-m1D"/>
+                            <constraint firstItem="1Jw-Ws-T0T" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="Kbz-TZ-d9K"/>
+                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="hXv-1T-mbc" secondAttribute="trailing" constant="50" id="Qrd-np-QV1"/>
+                            <constraint firstItem="hXv-1T-mbc" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="XW9-qT-dp9"/>
                             <constraint firstItem="x4k-D7-Mvh" firstAttribute="top" secondItem="Cyy-8b-GCg" secondAttribute="top" constant="50" id="djs-hu-hJD"/>
+                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="1Jw-Ws-T0T" secondAttribute="trailing" constant="50" id="haI-Rw-Lg7"/>
                             <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="x4k-D7-Mvh" secondAttribute="trailing" constant="50" id="mJB-PI-zyh"/>
                             <constraint firstItem="x4k-D7-Mvh" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="wPd-LN-GBn"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="GAM Banner" image="rectangle.3.offgrid.fill" catalog="system" selectedImage="rectangle.3.offgrid.fill" id="WaP-P0-dwN"/>
                     <connections>
+                        <outlet property="cachedBannerButton" destination="hXv-1T-mbc" id="G6q-wE-nPC"/>
+                        <outlet property="clearTargetingCacheButton" destination="1Jw-Ws-T0T" id="Kk2-ip-LUl"/>
                         <outlet property="loadBannerButton" destination="x4k-D7-Mvh" id="Yre-Zn-37w"/>
                         <outlet property="targetingOutput" destination="c00-PY-Cdm" id="qBw-qG-iVR"/>
                     </connections>

--- a/demo-ios-objc/demo-ios-objc/GAMBannerViewController.h
+++ b/demo-ios-objc/demo-ios-objc/GAMBannerViewController.h
@@ -10,8 +10,9 @@
 
 @interface GAMBannerViewController : UIViewController
 @property (weak, nonatomic) IBOutlet UIButton *loadBannerButton;
+@property (weak, nonatomic) IBOutlet UIButton *cachedBannerButton;
+@property (weak, nonatomic) IBOutlet UIButton *clearTargetingCacheButton;
 @property (weak, nonatomic) IBOutlet UITextView *targetingOutput;
 
 - (IBAction)loadBannerWithTargeting:(id)sender;
 @end
-

--- a/demo-ios-objc/demo-ios-objc/GAMBannerViewController.m
+++ b/demo-ios-objc/demo-ios-objc/GAMBannerViewController.m
@@ -31,13 +31,40 @@
     delegate.targetingOutput = self.targetingOutput;
 }
 
-- (void)loadBannerWithTargeting:(id)sender {
+- (IBAction)loadBannerWithTargeting:(id)sender {
     NSError *error = nil;
 
     [_targetingOutput setText:@"Calling /targeting API...\n\n"];
 
     [OPTABLE targetingAndReturnError:&error];
     [OPTABLE witness:@"GAMBannerViewController.loadBannerClicked" properties:@{ @"example": @"value" } error:&error];
+}
+
+- (IBAction)loadBannerWithTargetingFromCache:(id)sender {
+    NSError *error = nil;
+    DFPRequest *request = [DFPRequest request];
+    NSDictionary *keyvals = nil;
+
+    [_targetingOutput setText:@"Checking local targeting cache...\n\n"];
+
+    keyvals = [OPTABLE targetingFromCache];
+
+    if (keyvals != nil) {
+        request.customTargeting = keyvals;
+        NSLog(@"[OptableSDK] Cached targeting values found: %@", keyvals);
+        [_targetingOutput setText:[NSString stringWithFormat:@"%@\nFound cached data: %@\n", [_targetingOutput text], keyvals]];
+    } else {
+        [_targetingOutput setText:[NSString stringWithFormat:@"%@\nCache empty.\n",
+            [_targetingOutput text]]];
+    }
+
+    [self.bannerView loadRequest:request];
+    [OPTABLE witness:@"GAMBannerViewController.loadBannerClicked" properties:@{ @"example": @"value" } error:&error];
+}
+
+- (IBAction)clearTargetingCache:(id)sender {
+    [_targetingOutput setText:@"Clearing local targeting cache.\n\n"];
+    [OPTABLE targetingClearCache];
 }
 
 - (void)addBannerViewToView:(UIView *)bannerView {

--- a/demo-ios-objc/demo-ios-objc/IdentifyViewController.h
+++ b/demo-ios-objc/demo-ios-objc/IdentifyViewController.h
@@ -16,4 +16,3 @@
 
 - (IBAction)dispatchIdentify:(id)sender;
 @end
-

--- a/demo-ios-objc/demo-ios-objc/IdentifyViewController.m
+++ b/demo-ios-objc/demo-ios-objc/IdentifyViewController.m
@@ -23,7 +23,7 @@
     delegate.identifyOutput = self.identifyOutput;
 }
 
-- (void)dispatchIdentify:(id)sender {
+- (IBAction)dispatchIdentify:(id)sender {
     NSString *email = [_identifyInput text];
     bool aaid = [_identifyIDFA isOn];
     NSMutableString *output;

--- a/demo-ios-swift/Podfile.lock
+++ b/demo-ios-swift/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.67.1):
+  - Google-Mobile-Ads-SDK (7.68.0):
     - GoogleAppMeasurement (~> 7.0)
     - GoogleUserMessagingPlatform (~> 1.1)
   - GoogleAppMeasurement (7.0.0):
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: 4c11bba9a823ed16c42f14d42feebc7678fbfd6a
+  Google-Mobile-Ads-SDK: 29bbdb182d69ff606cc0301da1590b40be8d2205
   GoogleAppMeasurement: 7790ef975d1d463c8614cd949a847e612edf087a
   GoogleUserMessagingPlatform: 1d4b6946710d18cec34742054092e2c2bddae61f
   GoogleUtilities: ffb2f4159f2c897c6e8992bd7fbcdef8a300589c

--- a/demo-ios-swift/demo-ios-swift/Base.lproj/Main.storyboard
+++ b/demo-ios-swift/demo-ios-swift/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9KB-Po-ioE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9KB-Po-ioE">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,7 +20,7 @@
                                 <rect key="frame" x="20" y="64" width="374" height="168"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Address:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fu-DR-6Hn">
-                                        <rect key="frame" x="0.0" y="0.0" width="113" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="112" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -30,7 +31,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Include IDFA:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="78R-3b-x29">
-                                        <rect key="frame" x="0.0" y="70.5" width="101" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="70.5" width="100.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -38,7 +39,7 @@
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Eg-c7-IVu">
                                         <rect key="frame" x="0.0" y="99" width="51" height="31"/>
                                     </switch>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b7v-UN-xAf">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b7v-UN-xAf">
                                         <rect key="frame" x="0.0" y="138" width="374" height="30"/>
                                         <state key="normal" title="Identify"/>
                                         <connections>
@@ -55,19 +56,19 @@
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pQa-vV-MeS">
                                 <rect key="frame" x="20" y="256" width="343" height="217"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="AKp-3F-KNX" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" constant="-20" id="HKl-XJ-TO8"/>
                             <constraint firstItem="AKp-3F-KNX" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="SNe-0s-I2Q"/>
                             <constraint firstItem="AKp-3F-KNX" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="UII-5h-4Jn"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Identify" image="person.fill.badge.plus" catalog="system" selectedImage="person.fill.badge.plus" id="elC-Fm-1B7"/>
                     <connections>
@@ -89,33 +90,55 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4k-D7-Mvh">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4k-D7-Mvh">
                                 <rect key="frame" x="50" y="94" width="314" height="30"/>
-                                <state key="normal" title="Load Banner"/>
+                                <state key="normal" title="Load Targeting and Banner"/>
                                 <connections>
                                     <action selector="loadBannerWithTargeting:" destination="qnL-ha-uwz" eventType="touchUpInside" id="hBs-SW-Fgz"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Vm-D1-GlS">
+                                <rect key="frame" x="50" y="126" width="314" height="30"/>
+                                <state key="normal" title="Cached Targeting and Banner"/>
+                                <connections>
+                                    <action selector="loadBannerWithTargetingFromCache:" destination="qnL-ha-uwz" eventType="touchUpInside" id="GCp-rw-Bvc"/>
+                                </connections>
+                            </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="c00-PY-Cdm">
-                                <rect key="frame" x="50" y="157" width="314" height="370"/>
+                                <rect key="frame" x="50" y="213" width="314" height="381"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K3l-bf-R5v">
+                                <rect key="frame" x="50" y="158" width="314" height="30"/>
+                                <state key="normal" title="Clear Targeting Cache"/>
+                                <connections>
+                                    <action selector="clearTargetingCache:" destination="qnL-ha-uwz" eventType="touchUpInside" id="kbS-MK-t86"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <constraints>
-                            <constraint firstItem="x4k-D7-Mvh" firstAttribute="top" secondItem="Cyy-8b-GCg" secondAttribute="top" constant="50" id="djs-hu-hJD"/>
-                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="x4k-D7-Mvh" secondAttribute="trailing" constant="50" id="mJB-PI-zyh"/>
-                            <constraint firstItem="x4k-D7-Mvh" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="wPd-LN-GBn"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Cyy-8b-GCg"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="K3l-bf-R5v" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="GT3-Gh-h9q"/>
+                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="5Vm-D1-GlS" secondAttribute="trailing" constant="50" id="K8t-mK-5mT"/>
+                            <constraint firstItem="5Vm-D1-GlS" firstAttribute="top" secondItem="x4k-D7-Mvh" secondAttribute="bottom" constant="2" id="KHV-d6-1bP"/>
+                            <constraint firstItem="x4k-D7-Mvh" firstAttribute="top" secondItem="Cyy-8b-GCg" secondAttribute="top" constant="50" id="djs-hu-hJD"/>
+                            <constraint firstItem="K3l-bf-R5v" firstAttribute="top" secondItem="5Vm-D1-GlS" secondAttribute="bottom" constant="2" id="gVk-jq-hsm"/>
+                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="x4k-D7-Mvh" secondAttribute="trailing" constant="50" id="mJB-PI-zyh"/>
+                            <constraint firstItem="Cyy-8b-GCg" firstAttribute="trailing" secondItem="K3l-bf-R5v" secondAttribute="trailing" constant="50" id="pKU-OC-pbq"/>
+                            <constraint firstItem="x4k-D7-Mvh" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="wPd-LN-GBn"/>
+                            <constraint firstItem="5Vm-D1-GlS" firstAttribute="leading" secondItem="Cyy-8b-GCg" secondAttribute="leading" constant="50" id="y8L-ol-JVK"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="GAM Banner" image="rectangle.3.offgrid.fill" catalog="system" selectedImage="rectangle.3.offgrid.fill" id="WaP-P0-dwN"/>
                     <connections>
+                        <outlet property="clearTargetingCacheButton" destination="K3l-bf-R5v" id="eYH-ua-b52"/>
                         <outlet property="loadBannerButton" destination="x4k-D7-Mvh" id="oRn-LX-7Gx"/>
+                        <outlet property="loadBannerFromCacheButton" destination="5Vm-D1-GlS" id="3Xc-pA-qXe"/>
                         <outlet property="targetingOutput" destination="c00-PY-Cdm" id="E8P-NS-BGr"/>
                     </connections>
                 </viewController>
@@ -144,7 +167,13 @@
         </scene>
     </scenes>
     <resources>
-        <image name="person.fill.badge.plus" catalog="system" width="128" height="116"/>
+        <image name="person.fill.badge.plus" catalog="system" width="128" height="124"/>
         <image name="rectangle.3.offgrid.fill" catalog="system" width="128" height="81"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/demo-ios-swift/demo-ios-swift/GAMBannerViewController.swift
+++ b/demo-ios-swift/demo-ios-swift/GAMBannerViewController.swift
@@ -15,6 +15,8 @@ class GAMBannerViewController: UIViewController {
 
     //MARK: Properties
     @IBOutlet weak var loadBannerButton: UIButton!
+    @IBOutlet weak var loadBannerFromCacheButton: UIButton!
+    @IBOutlet weak var clearTargetingCacheButton: UIButton!
     @IBOutlet weak var targetingOutput: UITextView!
 
     override func viewDidLoad() {
@@ -56,6 +58,28 @@ class GAMBannerViewController: UIViewController {
         } catch {
             print("[OptableSDK] Exception: \(error)")
         }
+    }
+
+    @IBAction func loadBannerWithTargetingFromCache(_ sender: UIButton) {
+        var tdata: NSDictionary = [:]
+
+        targetingOutput.text = "Checking local targeting cache...\n\n"
+
+        let cachedValues = OPTABLE!.targetingFromCache()
+        if (cachedValues != nil) {
+            print("[OptableSDK] Cached targeting values found: \(cachedValues!)")
+            targetingOutput.text += "Found cached data: \(cachedValues!)\n"
+            tdata = cachedValues!
+        } else {
+            targetingOutput.text += "Cache empty.\n"
+        }
+
+        self.loadBanner(adUnitID: "/22081946781/ios-sdk-demo/mobile-leaderboard", keyvalues: tdata)
+    }
+
+    @IBAction func clearTargetingCache(_ sender: UIButton) {
+        targetingOutput.text = "Clearing local targeting cache.\n"
+        OPTABLE!.targetingClearCache()
     }
 
     private func loadBanner(adUnitID: String, keyvalues: NSDictionary) {


### PR DESCRIPTION
targetingFromCache and targetingClearCache APIs

- targeting API now also caches returned keyvalues to client storage
- targetingFromCache will fetch previously cached keyvalues from client storage. Contrary to the targeting API, it does not block and is synchronous.
- targetingClearCache will clear any previously cached keyvalues
- Update demo-ios-{objc,swift} to show usage of targetingFromCache
- Update demo-ios-{objc,swift} to show usage of targetingClearCache
- Update README with targeting*Cache docs