### PR TITLE
Support useragent override in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ OPTABLE = OptableSDK(host: "sandbox.customer.com", app: "my-app", insecure: true
 
 However, since production sandboxes only listen to TLS traffic, the above is really only useful for developers of `optable-sandbox` running the sandbox locally for testing.
 
+By default, the SDK detects the application user agent by sniffing `navigator.userAgent` from a `WKWebView`. The resulting user agent string is sent to your sandbox for analytics purposes. To disable this behavior, you can provide an optional fourth string parameter, `useragent`, which allows you to set whatever user agent string you would like to send instead. For example:
+
+```swift
+OPTABLE = OptableSDK(host: "sandbox.customer.com", app: "my-app", insecure: false, useragent: "custom-ua")
+```
+
+The default value of `nil` for the `useragent` parameter enables the `WKWebView` auto-detection behavior.
+
 ### Identify API
 
 To associate a user device with an authenticated identifier such as an Email address, or with other known IDs such as the Apple ID for Advertising (IDFA), or even your own vendor or app level `PPID`, you can call the `identify` API as follows:
@@ -312,7 +320,8 @@ OptableSDK *OPTABLE = nil;
   ...
     OPTABLE = [[OptableSDK alloc] initWithHost: @"sandbox.optable.co"
                                   app: @"ios-sdk-demo"
-                                  insecure: NO];
+                                  insecure: NO
+                                  useragent: nil];
     OptableSDKDelegate *delegate = [[OptableSDKDelegate alloc] init];
     OPTABLE.delegate = delegate;
   ...
@@ -321,6 +330,8 @@ OptableSDK *OPTABLE = nil;
 ```
 
 You can call various SDK APIs on the instance as shown in the examples below. It's also possible to configure multiple instances of `OptableSDK` in order to connect to other (e.g., partner) sandboxes and/or reference other configured application slug IDs. Note that the `insecure` flag should always be set to `NO` unless you are testing a local instance of the `optable-sandbox` yourself.
+
+You can disable user agent `WKWebView` based auto-detection and provide your own value by setting the `useragent` parameter to a string value, similar to the Swift example.
 
 ### Identify API
 

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -12,6 +12,7 @@ struct Config {
     var host: String
     var app: String
     var insecure: Bool
+    var useragent: String?
 
     func edgeURL(_ path: String) -> URL? {
         var proto = "https://"

--- a/Source/Core/Client.swift
+++ b/Source/Core/Client.swift
@@ -16,8 +16,12 @@ class Client {
 
     init(_ config: Config) {
         self.storage = LocalStorage(config)
-        self.userAgent { (realUserAgent) in
-            self.ua = realUserAgent
+        if (config.useragent == nil) {
+            self.userAgent { (realUserAgent) in
+                self.ua = realUserAgent
+            }
+        } else {
+            self.ua = config.useragent
         }
     }
 

--- a/Source/OptableSDK.swift
+++ b/Source/OptableSDK.swift
@@ -65,8 +65,8 @@ public class OptableSDK: NSObject {
     //  OptableSDK(host, app) returns an instance of the SDK configured to talk to the sandbox specified by host & app:
     //
     @objc
-    public init(host: String, app: String, insecure: Bool = false) {
-        self.config = Config(host: host, app: app, insecure: insecure)
+    public init(host: String, app: String, insecure: Bool = false, useragent: String? = nil) {
+        self.config = Config(host: host, app: app, insecure: insecure, useragent: useragent)
         self.client = Client(self.config)
     }
 

--- a/demo-ios-objc/demo-ios-objc/AppDelegate.m
+++ b/demo-ios-objc/demo-ios-objc/AppDelegate.m
@@ -20,7 +20,7 @@ OptableSDK *OPTABLE = nil;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
     
-    OPTABLE = [[OptableSDK alloc] initWithHost: @"sandbox.optable.co" app: @"ios-sdk-demo" insecure: NO];
+    OPTABLE = [[OptableSDK alloc] initWithHost: @"sandbox.optable.co" app: @"ios-sdk-demo" insecure: NO useragent: nil];
     OptableSDKDelegate *delegate = [[OptableSDKDelegate alloc] init];
     OPTABLE.delegate = delegate;
 


### PR DESCRIPTION
When initializing the `OptableSDK` constructor, it's now possible to override the otherwise internally assigned user-agent string, with one specified by the caller. The caller-specified useragent is of course optional and, if one is not assigned (or nil is passed as the useragent at initialization time) then the default is to continue to create an invisible WebView and extract the user-agent string from it. If a caller specifies a non-nil useragent string, then we use it instead.

Closes https://github.com/Optable/optable-ios-sdk/issues/23